### PR TITLE
enable dryrun

### DIFF
--- a/roles/homebrew_cask/tasks/main.yml
+++ b/roles/homebrew_cask/tasks/main.yml
@@ -14,10 +14,12 @@
     failed_when: false
     changed_when: false
     register: service_docker_status
+    when: not ansible_check_mode
 
   - name: launch docker
     command: open /Applications/Docker.app
     when: service_docker_status.rc != 0
+    ignore_errors: "{{ ansible_check_mode }}"
 
   tags:
     - homebrew_cask


### PR DESCRIPTION
## やったこと
- dryrun modeで実行した際にdocker processの有無を条件にしている処理がエラーになるので、dryrun時はignoreにした

## 確認結果
`% ansible-playbook --check --diff setup.yml -i inventory`
```result
PLAY RECAP *************************************************************************************************************************************************************************************************************************************
127.0.0.1                  : ok=8    changed=2    unreachable=0    failed=0    skipped=3    rescued=0    ignored=1   
```